### PR TITLE
SAGE 1249: Add vsn

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This will only work once node has registered.
 ```bash
 curl localhost:5000/node/0000000000000001 -d '{"assign_beehive": "my-beehive"}'
 curl localhost:5000/node/0000000000000001 -d '{"deploy_wes": true}'
+curl localhost:5000/node/0000000000000001 -d '{"vsn": true}'
 ```
 
 Check the logs:

--- a/README.md
+++ b/README.md
@@ -46,12 +46,18 @@ curl localhost:5000/beehives/my-beehive | jq .
 ```
 # assign node to a beehive
 
-This will only work once node has registered.
+The next set of commands will only work once the node has registered.
 
+VSN can be obtained from the node by:
+```bash
+curl localhost:5000/node/0000000000000001 -d '{"vsn": true}'
+```
+Getting the VSN can be done before or after the assignment of beehive or deploying the wes services.
+
+The next commands will assign a beehive and deploy the WES services.
 ```bash
 curl localhost:5000/node/0000000000000001 -d '{"assign_beehive": "my-beehive"}'
 curl localhost:5000/node/0000000000000001 -d '{"deploy_wes": true}'
-curl localhost:5000/node/0000000000000001 -d '{"vsn": true}'
 ```
 
 Check the logs:

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -940,7 +940,7 @@ def add_vsn(node_id):
         raise Exception(f"vsn invalid type")
 
     try:
-        register_add_vsn_event(node_id,vsn_val_str,lock_tables=True, lock_requested_by="vsn")
+        register_add_vsn_event(node_id,vsn_val_str,lock_tables=True, lock_requested_by="vsn_retrieval")
     except Exception as e:
         raise Exception(f"add_vsn_event_failed failed: {str(e)}")
     return {"success":True}

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -916,7 +916,6 @@ def register_add_vsn_event(node_id,field_value, lock_tables=True, lock_requested
     payload = {"node_id": node_id, "source": "beekeeper-add-vsn", "operation":"insert", 
                 "field_name": "vsn", "field_value": field_value}
 
-    #url = f'{BEEKEEPER_DB_API}/log'
     try:
         insert_log(payload, lock_tables=lock_tables, lock_requested_by=lock_requested_by)
     except Exception as e:

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -585,7 +585,7 @@ def scp(source, node_id, target):
 
 
 
-def node_ssh(node_id, command, input_str=None,quiet_mode=False):
+def node_ssh(node_id, command, input_str=None, quiet_mode=False):
     proxy_cmd = f"ProxyCommand=ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{BEEKEEPER_SSHD_HOST} -p 2201 -i /config/admin-key/admin.pem"
     ssh_cmd =  ["ssh",
                 #"-tt",
@@ -926,7 +926,7 @@ def register_add_vsn_event(node_id,field_value, lock_tables=True, lock_requested
 def add_vsn(node_id):
     command = "cat /etc/waggle/vsn"
     try:
-        result_stdout_str ,result_stderr_str, exit_code = node_ssh(node_id, command,quiet_mode=True)
+        result_stdout_str ,result_stderr_str, exit_code = node_ssh(node_id, command, quiet_mode=True)
         logger.debug(f"(add_vsn) vsn on node: {result_stdout_str}")
     except Exception as e:
         raise Exception(f"node_ssh failed: {str(e)} with command: {command}")

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -585,17 +585,25 @@ def scp(source, node_id, target):
 
 
 
-def node_ssh(node_id, command, input_str=None):
+def node_ssh(node_id, command, input_str=None,quiet_mode=False):
+    proxy_cmd = f"ProxyCommand=ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{BEEKEEPER_SSHD_HOST} -p 2201 -i /config/admin-key/admin.pem"
     ssh_cmd =  ["ssh",
-            #"-tt",
-            "-i", node_key , # this must be the key that allows ssh into the node , this key might be the same for all nodes
-            "-o", "UserKnownHostsFile=/dev/null",
-            "-o", "StrictHostKeyChecking=no",
-            "-o", "IdentitiesOnly=true",
-            "-o" ,f"ProxyCommand=ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{BEEKEEPER_SSHD_HOST} -p 2201 -i /config/admin-key/admin.pem  netcat -U /home_dirs/node-{node_id}/rtun.sock",
-            f"root@foo:",
-            command]
+                #"-tt",
+                "-i", node_key , # this must be the key that allows ssh into the node , this key might be the same for all nodes
+                "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "StrictHostKeyChecking=no",
+                "-o", "IdentitiesOnly=true",
+                ]
 
+    if quiet_mode:
+        proxy_cmd += " -q" 
+        ssh_cmd.append('-q')
+    
+    proxy_cmd += f" netcat -U /home_dirs/node-{node_id}/rtun.sock"
+    ssh_cmd.append("-o")
+    ssh_cmd.append(proxy_cmd)
+    ssh_cmd.append(f"root@foo:")
+    ssh_cmd.append(command)
 
     ssh_cmd_str = " ".join(ssh_cmd)
     logger.debug(ssh_cmd_str)
@@ -903,7 +911,39 @@ cd /opt/waggle-edge-stack/kubernetes
     return {"success":True}
 
 
+def register_add_vsn_event(node_id,field_value, lock_tables=True, lock_requested_by=""):
 
+    payload = {"node_id": node_id, "source": "beekeeper-add-vsn", "operation":"insert", 
+                "field_name": "vsn", "field_value": field_value}
+
+    #url = f'{BEEKEEPER_DB_API}/log'
+    try:
+        insert_log(payload, lock_tables=lock_tables, lock_requested_by=lock_requested_by)
+    except Exception as e:
+        raise Exception(f"insert_log returned: {str(e)}")
+    return
+
+def add_vsn(node_id):
+    command = "cat /etc/waggle/vsn"
+    try:
+        result_stdout_str ,result_stderr_str, exit_code = node_ssh(node_id, command,quiet_mode=True)
+        logger.debug(f"(add_vsn) vsn on node: {result_stdout_str}")
+    except Exception as e:
+        raise Exception(f"node_ssh failed: {str(e)} with command: {command}")
+    
+    vsn_val_str = str(result_stdout_str).rstrip()
+    #is vsn empty or not an instance of str?
+    if isinstance( vsn_val_str, str ):
+        if vsn_val_str.strip() == '':
+            raise Exception(f"vsn is empty: {vsn_val_str}")
+    else:
+        raise Exception(f"vsn invalid type")
+
+    try:
+        register_add_vsn_event(node_id,vsn_val_str,lock_tables=True, lock_requested_by="vsn")
+    except Exception as e:
+        raise Exception(f"add_vsn_event_failed failed: {str(e)}")
+    return {"success":True}
 
 def create_ssh_upload_cert(bee_db, node_id, beehive_obj, force=False ):
 
@@ -1077,6 +1117,15 @@ class Node(MethodView):
 
             return jsonify(result)
 
+        if "vsn" in postData:
+
+            try:
+                result = add_vsn(node_id)
+            except Exception as e:
+                logger.error(e)
+                raise ErrorResponse(f"add_vsn returned: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+            return jsonify(result)
 
 
 

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -143,9 +143,9 @@ def test_vsn_insert(client):
     #Check that the initial value is null
     rv = client.get(f'/state/0000000000000001')
     result_before_vsn = rv.get_json()
-    d_before_vsn = result_before_vsn["data"]["vsn"]
     assert 'error' not in result_before_vsn
     assert 'data' in result_before_vsn
+    d_before_vsn = result_before_vsn["data"]["vsn"]
     assert None == d_before_vsn
     #Check that we can populate vsn
     data = {"vsn": True}

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -139,6 +139,30 @@ def test_log_insert_fail(client):
     assert 'error'  in result
 
 
+def test_vsn_insert(client):
+    #Check that the initial value is null
+    rv = client.get(f'/state/0000000000000001')
+    result_before_vsn = rv.get_json()
+    d_before_vsn = result_before_vsn["data"]["vsn"]
+    assert 'error' not in result_before_vsn
+    assert 'data' in result_before_vsn
+    assert None == d_before_vsn
+    #Check that we can populate vsn
+    data = {"vsn": True}
+    rv = client.post('/node/0000000000000001', data = json.dumps(data))
+    result = rv.get_json()
+    assert "success" in result
+    #Check that the db is updated with the new value
+    gt_value = "TEST-minimal"
+    rv = client.get(f'/state/0000000000000001')
+    result = rv.get_json()
+    print(result)
+    assert 'error' not in result
+    assert 'data' in result
+
+    d_after_vsn = result["data"]["vsn"]
+    assert d_before_vsn != d_after_vsn
+    assert d_after_vsn == gt_value
 
 # TODO test full replay without timestamp
 def test_log_insert(client):
@@ -177,10 +201,9 @@ def test_log_insert(client):
         'server_node': None,
         'timestamp': (test_time - datetime.timedelta(days= 1)).isoformat(),
         'registration_event': (test_time - datetime.timedelta(days= 5)).isoformat(),
-        'wes_deploy_event': None
+        'wes_deploy_event': None,
+        'vsn': None,
     }
-
-
 
 def test_list_recent_state(client):
     bee_db = bk_api.BeekeeperDB()

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS Beekeeper.nodes_log (
 CREATE TABLE IF NOT EXISTS Beekeeper.nodes_history (
     `id`                    VARCHAR(16) NOT NULL,  /*  typically MAC address of the "main" device  */
     `timestamp`             TIMESTAMP(0) NOT NULL,
+    `vsn`                   VARCHAR(64),
     `name`                  VARCHAR(64),
     `project_id`            VARCHAR(64),
     `mode`                  VARCHAR(64),


### PR DESCRIPTION
Summary of changes:
- Allow for quiet mode in the node_ssh function. This allows to be able to just directly get data from the command that is sent through the ssh tunnerl. Defaults are left as before.
- I am just doing a simple `cat /etc/waggle/vsn` on the node.
- Add new unit test for vsn.