### PR TITLE
Sage 1257: Allow to redeploy wes services if a node is re-flashed in the factory.

### DIFF
--- a/bk-deploy-manager/deploy_manager.py
+++ b/bk-deploy-manager/deploy_manager.py
@@ -48,15 +48,17 @@ def get_candidates():
 
     for n in nodes["data"]:
         node_id = n["id"]
+        registration_event = n.get("registration_event")
+        wes_deploy_event = n.get("wes_deploy_event")
         # print("id: "+node_id)
         # print("wes_deploy_event: "+n["wes_deploy_event"])
         if n.get("beehive") in ["", None]:
             logging.info(f"node {node_id} does not belong to a beehive")
             continue
 
-        if n.get("wes_deploy_event") in ["", None]:
+        if wes_deploy_event in ["", None] or parseTime(registration_event) >= parseTime(wes_deploy_event):
             logging.info(
-                f"scheduling node {node_id} for wes deployment (reason: no previous deployment)"
+                f"scheduling node {node_id} for wes deployment (reason: no previous deployment or re-registered node)"
             )
             candidates.append(n)
             continue

--- a/bk-deploy-manager/deploy_manager.py
+++ b/bk-deploy-manager/deploy_manager.py
@@ -52,6 +52,10 @@ def get_candidates():
         wes_deploy_event = n.get("wes_deploy_event")
         # print("id: "+node_id)
         # print("wes_deploy_event: "+n["wes_deploy_event"])
+        if registration_event in ["", None]:
+            logging.info("node %s is not registered", node_id)
+            continue
+
         if n.get("beehive") in ["", None]:
             logging.info(f"node {node_id} does not belong to a beehive")
             continue


### PR DESCRIPTION
WES services are not redeploy to nodes if a node is re-registered with beekeeper which happens if a node is re-flashed.

If the node is re-registered the `registration_event` will updated but not the `wes_deploy_event`, so we just need to check that `registration_event>=wes_deploy_event`. 

We want to always keep this state always true in the DB:
```
registration_event < wes_deploy_event
```