### PR TITLE
Added --fail to curl in register.sh to cause shell script to signal failure.

### DIFF
--- a/bk-sshd/ROOTFS/opt/sage/beekeeper/register/register.sh
+++ b/bk-sshd/ROOTFS/opt/sage/beekeeper/register/register.sh
@@ -38,7 +38,7 @@ case "${command}" in
       params="${params}&beehive_id=${beehive}"
     fi
 
-    curl -s -X POST "${bk_register_url}/register?${params}"
+    curl -s --fail -X POST "${bk_register_url}/register?${params}"
     ;;
   *)
     echo "invalid command"


### PR DESCRIPTION
Added --fail to curl inside register.sh to "forward" failed HTTP status code from API response.