### PR TITLE
Sage 1477 patch dev k8s manifest

### DIFF
--- a/kubernetes/dev-vm/kustomization.yaml
+++ b/kubernetes/dev-vm/kustomization.yaml
@@ -25,10 +25,10 @@ secretGenerator:
 images:
 - name: waggle/beekeeper-sshd
   newName: waggle/beekeeper-sshd
-  newTag: latest
+  newTag: v0.7.0
 - name: waggle/beekeeper-api
   newName: waggle/beekeeper-api
-  newTag: latest
+  newTag: v0.7.0
 - name: waggle/node-platforms
   newName: waggle/node-platforms
-  newTag: latest
+  newTag: 0.2.0

--- a/kubernetes/dev-vm/virtual-node.yaml
+++ b/kubernetes/dev-vm/virtual-node.yaml
@@ -21,7 +21,7 @@ spec:
           image: waggle/node-platforms:0.1.0
           command: [ "bash", "-c"]
           args:
-          - export ID=$(echo $POD_NAME | sed "s/$APP_NAME//" | sed "s/-//g" | tr '[:lower:]' '[:upper:]') && echo $ID > /etc/waggle/node-id && echo VSN$ID > /etc/waggle/vsn && /entrypoint.sh
+          - export ID=$(echo $POD_NAME | sed "s/$APP_NAME//" | sed "s/-//g" | tr '[:lower:]' '[:upper:]') && echo $ID > /etc/waggle/node-id && echo $ID > /etc/waggle/vsn && /entrypoint.sh
           volumeMounts:
             - name: ca-public
               mountPath: "/etc/waggle/beekeeper_ca_key.pub"

--- a/kubernetes/dev/kustomization.yaml
+++ b/kubernetes/dev/kustomization.yaml
@@ -50,7 +50,7 @@ secretGenerator:
 images:
 - name: waggle/beekeeper-sshd
   newName: waggle/beekeeper-sshd
-  newTag: latest
+  newTag: v0.7.0
 - name: waggle/beekeeper-api
   newName: waggle/beekeeper-api
-  newTag: latest
+  newTag: v0.7.0


### PR DESCRIPTION
Change beekeeper services to v0.7.0 and vm to 0.2.0 from latest (not
pushed to this tag anymore).

Remove the extra characters to comply with the size of VSN in sql
schema.

This fixes the VSN pulling from the virtual node.