### PR TITLE
Sage-1506: Add VSN during "registration".

### DIFF
--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -706,6 +706,11 @@ def deploy_wes(node_id, this_debug, force=False):
     logger.debug("(deploy_wes) checking if kubernetes is running on node %s", node_id)
 
     try:
+        add_vsn(node_id)
+    except Exception as e:
+        raise Exception(f"add_vsn failed: {e}")
+
+    try:
         proxy.check_call(["kubectl", "get", "nodes"])
     except Exception:
         raise Exception(f"deploy_wes: kubectl get nodes check failed for {node_id}")
@@ -860,12 +865,6 @@ cd /opt/waggle-edge-stack/kubernetes
         register_wes_deployment_event(node_id, lock_tables=True, lock_requested_by="wes_deployment")
     except Exception as e:
         raise Exception(f"register_wes_deployment_event failed: {str(e)}")
-
-    # add vsn as last step of deploy_wes
-    try:
-        add_vsn(node_id)
-    except Exception as e:
-        raise Exception(f"add_vsn failed: {e}")
 
     if this_debug:
         return {

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -879,6 +879,9 @@ def add_vsn_event(node_id,field_value, lock_tables=True, lock_requested_by=""):
         raise Exception(f"insert_log returned: {str(e)}")
     return
 
+# vsn must consist of at most 8 uppercase letters or numbers
+valid_vsn_pattern = re.compile("[A-Z0-9]{,8}$")
+
 def add_vsn(node_id):
     proxy = get_default_node_subprocess_proxy(node_id)
 
@@ -887,7 +890,10 @@ def add_vsn(node_id):
     except Exception:
         raise Exception(f"add_vsn: failed to fetch vsn for node {node_id}")
 
-    vsn = output.strip().upper()
+    vsn = output.strip()
+
+    if not valid_vsn_pattern.match(vsn):
+        raise ValueError(f"add_vsn: invalid vsn {vsn} for node {node_id}")
 
     try:
         add_vsn_event(node_id, vsn, lock_tables=True, lock_requested_by="vsn_retrieval")

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -708,6 +708,7 @@ def deploy_wes(node_id, this_debug, force=False):
     try:
         add_vsn(node_id)
     except Exception as e:
+        logger.error("add_vsn failed during deploy_wes for node %s", node_id)
         raise Exception(f"add_vsn failed: {e}")
 
     try:
@@ -1064,24 +1065,23 @@ class Node(MethodView):
             try:
                 set_node_beehive(node_id, assign_beehive)
             except Exception as e:
-                logger.error(e)
-                raise ErrorResponse(f"set_node_beehive returned: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+                logger.exception("assign_beehive failed: %s", e)
+                raise ErrorResponse(f"set_node_beehive failed: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         if "deploy_wes" in postData:
             try:
                 result = deploy_wes(node_id, this_debug, force=force)
             except Exception as e:
-                logger.error(e)
-                raise ErrorResponse(f"deploy_wes returned: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+                logger.exception("deploy_wes failed: %s", e)
+                raise ErrorResponse(f"deploy_wes failed: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
             return jsonify(result)
 
         if "vsn" in postData:
             try:
                 result = add_vsn(node_id)
             except Exception as e:
-                logger.error(e)
-                raise ErrorResponse(f"add_vsn returned: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
-
+                logger.exception("add_vsn failed: %s", e)
+                raise ErrorResponse(f"add_vsn failed: { type(e).__name__ }: {str(e)} {ShowException()}" , status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return jsonify({"success": True})
 

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -72,7 +72,7 @@ node_key = "/config/nodes/nodes.pem"
 
 
 valid_node_id_pattern = re.compile(r"[A-Z0-9]{6,16}")
-valid_vsn_pattern = re.compile(r"[A-Z][0-9]{3}")
+valid_vsn_pattern = re.compile(r"[A-Z][A-Z0-9]{3}")
 
 
 def ShowException():

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -543,7 +543,7 @@ def scp(source, node_id, target):
 
     return result_stdout ,result_stderr, exit_code
 
-def get_default_node_subprocess_proxy(node_id):
+def get_cluster_node_subprocess_proxy(node_id):
     return NodeSubprocessProxy(
         node_id=node_id,
         node_key=node_key,
@@ -666,7 +666,7 @@ def kube_secret(name, data):
 def deploy_wes(node_id, this_debug, force=False):
     logger.debug("(deploy_wes) determine correct beehive")
 
-    proxy = get_default_node_subprocess_proxy(node_id)
+    proxy = get_cluster_node_subprocess_proxy(node_id)
 
     assign_beehive = ""
     bee_db = None
@@ -880,7 +880,7 @@ cd /opt/waggle-edge-stack/kubernetes
     return {"success":True}
 
 def add_vsn(node_id):
-    proxy = get_default_node_subprocess_proxy(node_id)
+    proxy = get_cluster_node_subprocess_proxy(node_id)
 
     output = proxy.check_output(["cat", "/etc/waggle/vsn"], text=True)
     vsn = output.strip()

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -542,6 +542,8 @@ def scp(source, node_id, target):
 
     return result_stdout, result_stderr, exit_code
 
+# TODO(sean) migrate this and other dependent functions to use node subprocess proxy. this will
+# allow more control during unit testing.
 def node_ssh(node_id, command, input_str=None, quiet_mode=False):
     proxy_cmd = f"ProxyCommand=ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@{BEEKEEPER_SSHD_HOST} -p 2201 -i /config/admin-key/admin.pem"
     ssh_cmd =  ["ssh",

--- a/bk-api/bk_api.py
+++ b/bk-api/bk_api.py
@@ -71,8 +71,8 @@ beehives_root = '/beehives'
 node_key = "/config/nodes/nodes.pem"
 
 
-valid_node_id_pattern = re.compile("[A-Z0-9]{6,16}")
-valid_vsn_pattern = re.compile("[A-Z0-9]{3,8}")
+valid_node_id_pattern = re.compile(r"[A-Z0-9]{6,16}")
+valid_vsn_pattern = re.compile(r"[A-Z][0-9]{3}")
 
 
 def ShowException():

--- a/bk-api/bk_db.py
+++ b/bk-api/bk_db.py
@@ -1,21 +1,38 @@
 import MySQLdb
-import config
 import dateutil.parser
-import sys
+import os
 import time
 import logging
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
 table_fields = {}
-table_fields_index ={}
+table_fields_index = {}
+
 
 class ObjectNotFound(Exception):
     pass
 
-class BeekeeperDB():
-    def __init__ ( self , retries=60) :
 
+class Config(NamedTuple):
+    mysql_host: str
+    mysql_db: str
+    mysql_user: str
+    mysql_password: str
+
+
+default_config = Config(
+    mysql_host=os.getenv('MYSQL_HOST'),
+    mysql_db=os.getenv('MYSQL_DATABASE'),
+    mysql_user=os.getenv('MYSQL_USER'),
+    mysql_password=os.getenv('MYSQL_PASSWORD'),
+)
+
+
+class BeekeeperDB():
+
+    def __init__ (self, retries=60, config=default_config):
         if not config.mysql_host:
             raise Exception("MYSQL_HOST is not defined")
 
@@ -539,7 +556,6 @@ class BeekeeperDB():
 
         return self.cur.rowcount
 
-
     def dict2mysql(self, obj):
         fields = []
         values = []
@@ -554,11 +570,7 @@ class BeekeeperDB():
 
         return fields_str, values, replacement_str
 
-
-
     def truncate_table(self, table_name):
         stmt = f'TRUNCATE TABLE `{table_name}`'
         logger.debug(f'statement: {stmt}')
         self.cur.execute(stmt)
-
-

--- a/bk-api/bk_db.py
+++ b/bk-api/bk_db.py
@@ -6,6 +6,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# TODO(sean) this should probably not be a global... we should look at how to either not need this at all or move it into the DB object.
 table_fields = {}
 table_fields_index = {}
 

--- a/bk-api/bk_db.py
+++ b/bk-api/bk_db.py
@@ -17,16 +17,16 @@ class BeekeeperDB:
 
     def __init__(self, host, database, user, password, retries=60):
         if not host:
-            raise Exception("MYSQL_HOST is not defined")
+            raise Exception("host is not defined")
 
         if not database:
-            raise Exception("MYSQL_DATABASE is not defined")
+            raise Exception("database is not defined")
 
         if not user:
-            raise Exception("MYSQL_USER is not defined")
+            raise Exception("user is not defined")
 
         if not password:
-            raise Exception("MYSQL_PASSWORD is not defined")
+            raise Exception("password is not defined")
 
         # NOTE(sean) I don't think we want the retry logic to live inside this function but instead managed by the caller.
         #

--- a/bk-api/bk_db.py
+++ b/bk-api/bk_db.py
@@ -3,7 +3,6 @@ import dateutil.parser
 import os
 import time
 import logging
-from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -11,38 +10,21 @@ table_fields = {}
 table_fields_index = {}
 
 
-class ObjectNotFound(Exception):
-    pass
+class BeekeeperDB:
 
+    # TODO(sean) make this a context manager to ensure cleanup after operations
 
-class Config(NamedTuple):
-    mysql_host: str
-    mysql_db: str
-    mysql_user: str
-    mysql_password: str
-
-
-default_config = Config(
-    mysql_host=os.getenv('MYSQL_HOST'),
-    mysql_db=os.getenv('MYSQL_DATABASE'),
-    mysql_user=os.getenv('MYSQL_USER'),
-    mysql_password=os.getenv('MYSQL_PASSWORD'),
-)
-
-
-class BeekeeperDB():
-
-    def __init__ (self, retries=60, config=default_config):
-        if not config.mysql_host:
+    def __init__(self, host, database, user, password, retries=60):
+        if not host:
             raise Exception("MYSQL_HOST is not defined")
 
-        if not config.mysql_db:
+        if not database:
             raise Exception("MYSQL_DATABASE is not defined")
 
-        if not config.mysql_user:
+        if not user:
             raise Exception("MYSQL_USER is not defined")
 
-        if not config.mysql_password:
+        if not password:
             raise Exception("MYSQL_PASSWORD is not defined")
 
         # NOTE(sean) I don't think we want the retry logic to live inside this function but instead managed by the caller.
@@ -55,8 +37,7 @@ class BeekeeperDB():
         count = 0
         while True:
             try:
-                self.db=MySQLdb.connect(host=config.mysql_host,user=config.mysql_user,
-                  passwd=config.mysql_password,db=config.mysql_db)
+                self.db = MySQLdb.connect(host=host, user=user, passwd=password, db=database)
             except Exception as e: # pragma: no cover
                 if count > retries:
                     raise

--- a/bk-api/config.py
+++ b/bk-api/config.py
@@ -1,6 +1,0 @@
-import os
-
-mysql_host = os.getenv('MYSQL_HOST')
-mysql_db = os.getenv('MYSQL_DATABASE')
-mysql_user = os.getenv('MYSQL_USER')
-mysql_password = os.getenv('MYSQL_PASSWORD')

--- a/bk-api/node_subprocess_proxy.py
+++ b/bk-api/node_subprocess_proxy.py
@@ -11,9 +11,9 @@ class NodeSubprocessProxy:
         self.proxy_key = proxy_key
         self.proxy_user = proxy_user
         self.extra_args = []
-
         if quiet:
             self.extra_args += ["-q"]
+        # TODO(sean) add a logger here so you can easily enable/disable proxy instance logging in one place
 
     def _wrap(self, cmd):
         return [

--- a/bk-api/node_subprocess_proxy.py
+++ b/bk-api/node_subprocess_proxy.py
@@ -29,9 +29,6 @@ class NodeSubprocessProxy:
             *cmd,
         ]
 
-    def run(self, cmd, *args, **kwargs):
-        return subprocess.run(self._wrap(cmd), *args, **kwargs)
-
     def check_call(self, cmd, *args, **kwargs):
         return subprocess.check_call(self._wrap(cmd), *args, **kwargs)
 

--- a/bk-api/node_subprocess_proxy.py
+++ b/bk-api/node_subprocess_proxy.py
@@ -1,0 +1,39 @@
+import subprocess
+
+
+class NodeSubprocessProxy:
+
+    def __init__(self, node_id, node_key, proxy_host, proxy_port, proxy_key, proxy_user="root", quiet=True):
+        self.node_id = node_id
+        self.node_key = node_key
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
+        self.proxy_key = proxy_key
+        self.proxy_user = proxy_user
+        self.extra_args = []
+
+        if quiet:
+            self.extra_args += ["-q"]
+
+    def _wrap(self, cmd):
+        return [
+            "ssh",
+            *self.extra_args,
+            "-i", self.node_key,
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "IdentitiesOnly=true",
+            "-o", f"ProxyCommand=ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {self.proxy_user}@{self.proxy_host} -p {self.proxy_port} -i {self.proxy_key} netcat -U /home_dirs/node-{self.node_id.upper()}/rtun.sock",
+            "root@foo", # proxy command will set proxy settings
+            "--",
+            *cmd,
+        ]
+
+    def run(self, cmd, *args, **kwargs):
+        return subprocess.run(self._wrap(cmd), *args, **kwargs)
+
+    def check_call(self, cmd, *args, **kwargs):
+        return subprocess.check_call(self._wrap(cmd), *args, **kwargs)
+
+    def check_output(self, cmd, *args, **kwargs):
+        return subprocess.check_output(self._wrap(cmd), *args, **kwargs)

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -32,6 +32,7 @@ def wipe_db():
         db.truncate_table("nodes_log")
         db.truncate_table("nodes_history")
         db.truncate_table("beehives")
+        # TODO(sean) truncate all tables and stop depending on on data outside of the unit tests
 
 
 @pytest.fixture

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -12,7 +12,7 @@ from contextlib import closing
 
 @pytest.fixture
 def app():
-    # TODO(sean) This is a hack to prevent accidentally wiping the production tables if someone accidentally. We
+    # TODO(sean) This is a hack to prevent accidentally wiping the production tables if someone accidentally runs the tests. We
     # should move to a dedicated TestBeekeeper database instead.
     if os.getenv("TESTING") != "1":
         raise RuntimeError("Bailing out on running tests as they wipe the database! If you are not running in production and are sure you want to proceed, you must set the env var TESTING=1.")

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -219,7 +219,7 @@ def test_vsn_insert_success(app, client):
     Tests add VSN success behavior.
     """
     app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
-        (["cat", "/etc/waggle/vsn"], 0, "V001"),
+        (["cat", "/etc/waggle/vsn"], 0, "V001\n"),
     ])
 
     node_id = "0000000000000001"
@@ -249,7 +249,7 @@ def test_add_vsn_proxy_error(app, client):
     Tests add vsn behavior when proxy commands fail.
     """
     app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
-        (["cat", "/etc/waggle/vsn"], 1, "V123"),
+        (["cat", "/etc/waggle/vsn"], 1, "V123\n"),
     ])
 
     node_id = "0000000000000001"

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -9,7 +9,6 @@ from http import HTTPStatus
 import re
 import os
 from contextlib import closing
-from functools import partial
 
 
 @pytest.fixture
@@ -219,7 +218,7 @@ def test_vsn_insert_success(app, client):
     """
     Tests add VSN success behavior.
     """
-    app.node_subprocess_proxy_factory = partial(MockNodeSubprocessProxy, return_values=[
+    app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
         (["cat", "/etc/waggle/vsn"], 0, "V001"),
     ])
 
@@ -249,7 +248,7 @@ def test_add_vsn_proxy_error(app, client):
     """
     Tests add vsn behavior when proxy commands fail.
     """
-    app.node_subprocess_proxy_factory = partial(MockNodeSubprocessProxy, return_values=[
+    app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
         (["cat", "/etc/waggle/vsn"], 1, "V123"),
     ])
 
@@ -281,7 +280,7 @@ def test_add_vsn_validation(app, client):
     assert r.status_code == HTTPStatus.OK
 
     for testvalue in ["", "V01", "V 123", "v001", "2x13", "V1234"]:
-        app.node_subprocess_proxy_factory = partial(MockNodeSubprocessProxy, return_values=[
+        app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
             (["cat", "/etc/waggle/vsn"], 0, testvalue),
         ])
 
@@ -471,6 +470,11 @@ class MockNodeSubprocessProxy:
     """
     MockNodeSubprocessProxy provides a mock for the check_call and check_output node subprocess proxy methods.
     """
+
+    @classmethod
+    def make_factory(cls, return_values):
+        from functools import partial
+        return partial(MockNodeSubprocessProxy, return_values=return_values)
 
     def __init__(self, node_id, return_values=[]):
         self.node_id = node_id

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -217,7 +217,7 @@ def test_vsn_insert_contract(client):
 
 def test_vsn_insert_success(app, client):
     """
-    Tests behavior when add VSN trigger succeeds.
+    Tests add VSN success behavior.
     """
     app.node_subprocess_proxy_factory = partial(MockNodeSubprocessProxy, return_values=[
         (["cat", "/etc/waggle/vsn"], 0, "V001"),
@@ -246,6 +246,9 @@ def test_vsn_insert_success(app, client):
 
 
 def test_add_vsn_proxy_error(app, client):
+    """
+    Tests add vsn behavior when proxy commands fail.
+    """
     app.node_subprocess_proxy_factory = partial(MockNodeSubprocessProxy, return_values=[
         (["cat", "/etc/waggle/vsn"], 1, "V123"),
     ])
@@ -268,6 +271,9 @@ def test_add_vsn_proxy_error(app, client):
 
 
 def test_add_vsn_validation(app, client):
+    """
+    Tests add VSN validation checks.
+    """
     node_id = "0000000000000001"
 
     # assume node has registered

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -216,7 +216,7 @@ def test_vsn_insert_contract(client):
 
 def test_vsn_insert_success(app, client):
     """
-    Tests add VSN success behavior.
+    Tests add vsn trigger success behavior.
     """
     app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
         (["cat", "/etc/waggle/vsn"], 0, "V001\n"),
@@ -246,7 +246,7 @@ def test_vsn_insert_success(app, client):
 
 def test_add_vsn_proxy_error(app, client):
     """
-    Tests add vsn behavior when proxy commands fail.
+    Tests add vsn trigger behavior when proxy commands fail.
     """
     app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
         (["cat", "/etc/waggle/vsn"], 1, "V123\n"),
@@ -271,7 +271,7 @@ def test_add_vsn_proxy_error(app, client):
 
 def test_add_vsn_validation(app, client):
     """
-    Tests add VSN validation checks.
+    Tests add vsn trigger validation checks.
     """
     node_id = "0000000000000001"
 
@@ -279,7 +279,7 @@ def test_add_vsn_validation(app, client):
     r = client.post(f"/register?node_id={node_id}")
     assert r.status_code == HTTPStatus.OK
 
-    for testvalue in ["", "V01", "V 123", "v001", "2x13", "V1234"]:
+    for testvalue in ["", "\n", "V01\n", "V 123\n", "v001\n", "2x13\n", "V1234\n", "BAD-CHARS!\n", "V001\nV002\n"]:
         app.node_subprocess_proxy_factory = MockNodeSubprocessProxy.make_factory([
             (["cat", "/etc/waggle/vsn"], 0, testvalue),
         ])

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -1,6 +1,5 @@
 import subprocess
-from bk_api import create_app
-from bk_db import BeekeeperDB
+from bk_api import create_app, get_db
 import datetime
 import pytest
 import json
@@ -21,14 +20,18 @@ def app():
     # TODO(sean) It would be nice to setup a fresh database here, so different unit tests can't affect each other.
     # For example, we could generate some BeekeeperTestRandomID database and init the tables.
     app = create_app()
-    truncate_all_tables()
+
+    with app.app_context():
+        wipe_db()
+
     yield app
 
 
-def truncate_all_tables():
-    with closing(BeekeeperDB()) as db:
-        for table_name in ["nodes_log", "nodes_history", "beehives"]:
-            db.truncate_table(table_name)
+def wipe_db():
+    with closing(get_db()) as db:
+        db.truncate_table("nodes_log")
+        db.truncate_table("nodes_history")
+        db.truncate_table("beehives")
 
 
 @pytest.fixture

--- a/bk-api/test_bk_api.py
+++ b/bk-api/test_bk_api.py
@@ -179,7 +179,7 @@ def test_vsn_insert(client):
     result = rv.get_json()
     assert "success" in result
     #Check that the db is updated with the new value
-    gt_value = "TEST-MINIMAL"
+    gt_value = "T123"
     rv = client.get(f'/state/0000000000000001')
     result = rv.get_json()
     print(result)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - ./schema.sql:/docker-entrypoint-initdb.d/init.sql
   node1:
-    image: waggle/wes-minimal:0.3.0
+    image: waggle/node-platforms:0.3.0
     restart: always
     volumes:
       - ./beekeeper-keys/registration_certs/untilforever/registration:/etc/waggle/sage_registration_readonly:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,13 @@ services:
       - "127.0.0.1:5000:5000" # for testing purposes
   db:
     image: mysql:8.0.29
+    restart: always
     env_file: mysql.env
     volumes:
       - ./schema.sql:/docker-entrypoint-initdb.d/init.sql
   node1:
-    image: waggle/wes-minimal
+    image: waggle/wes-minimal:0.3.0
+    restart: always
     volumes:
       - ./beekeeper-keys/registration_certs/untilforever/registration:/etc/waggle/sage_registration_readonly:ro
       - ./beekeeper-keys/registration_certs/untilforever/registration-cert.pub:/etc/waggle/sage_registration-cert.pub_readonly:ro
@@ -48,3 +50,6 @@ services:
       - ./beekeeper-keys/bk-ca/beekeeper_ca_key.pub:/etc/waggle/beekeeper_ca_key.pub:ro
       # so beekeeper can ssh into it:
       - ./beekeeper-keys/node-ssh-key/nodes.pem.pub:/root/.ssh/authorized_keys:ro
+    environment:
+      - WAGGLE_NODE_ID=0000000000000001
+      - WAGGLE_NODE_VSN=V001

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,3 @@
-
-
 CREATE DATABASE IF NOT EXISTS Beekeeper;
 
 /* log of update operations */

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -22,4 +22,4 @@ done
 
 ### TEST BEEKEEPER API
 set -x
-docker exec -i $(docker-compose ps -q bk-api) /bin/bash -c 'coverage run -m pytest -v &&  coverage report -m --fail-under 85 --include=./*'
+docker exec -e TESTING=1 -i $(docker-compose ps -q bk-api) /bin/bash -c 'coverage run -m pytest -v &&  coverage report -m --fail-under 85 --include=./*'


### PR DESCRIPTION
This PR attempts to simplify getting VSNs into our database automatically.

Strictly speaking, adding a node during registration is not possible without other changes as the node will not have a reverse SSH tunnel.

However, this PR adds getting the VSN as a prerequisite to deploy WES. Since we attempt to deploy WES to unregistered nodes, this should be mostly equivalent.

Technical Notes:

I'm starting to clean up the way the we ssh to nodes by putting it behind a safer NodeSubprocessProxy object. This will give you all the usual safety that subprocess.check_call or subprocess.check_output provide.

Something like this would have helped prevent the error where we still added the VSN to the DB, even though the command failed.

Also, I've updated the behavior of add_vsn so it only inserts the VSN if it differs from the current state, so we don't end up with many duplicated entries.
